### PR TITLE
refactor: always use multiGet to take advantage of AsyncStorage's optimizations...

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,15 +32,13 @@ function parse (str = '') {
  * storage.get('foo').then(console.log).catch(console.error)
  */
 function get (key, def) {
-  if (Array.isArray(key)) {
-    return AsyncStorage.multiGet(key)
-      .then((values) => values.map(([_, value]) => {
-        return useDefault(def, value) ? def : parse(value)
-      }))
-      .then(results => Promise.all(results))
-  }
-
-  return AsyncStorage.getItem(key).then(value => useDefault(def, value) ? def : parse(value))
+  const isArray = Array.isArray(key)
+  return AsyncStorage.multiGet(isArray ? key : [key])
+    .then((values) => values.map(([_, value]) => {
+      return useDefault(def, value) ? def : parse(value)
+    }))
+    .then(results => Promise.all(results))
+    .then(results => isArray ? results : results[0])
 }
 
 /**


### PR DESCRIPTION
...for coalescing requests

see: https://github.com/react-native-community/react-native-async-storage/blob/master/lib/AsyncStorage.js#L204

see: https://github.com/mvayngrib/asperf

edit: hm, after more testing, it seems that for large mixed-size values, performance suffers!